### PR TITLE
conf.py: Fix sphinx error

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -24,6 +24,10 @@ master_doc = "index"
 
 html_show_sourcelink = False
 
+# This is also used if you do content translation via gettext catalogs.
+# Usually you set "language" from the command line for these cases.
+language = 'en'
+
 # -- General configuration ---------------------------------------------------
 
 # Add any Sphinx extension module names here, as strings. They can be


### PR DESCRIPTION
This avoids an error with sphinx 8.0.2:

Warning, treated as error: Invalid configuration value found: 'language = None'. Update your configuration to a valid language code. Falling back to 'en' (English).