### PR TITLE
Fix sphinx documentation style

### DIFF
--- a/_static/custom.css
+++ b/_static/custom.css
@@ -1,0 +1,12 @@
+@media screen and (max-width: 940px) {
+    div.document {
+        display: flex;
+        flex-direction: column-reverse;
+    }
+
+    div.document div.sphinxsidebar {
+        margin: -20px -30px 20px -30px;
+        width: unset;
+        left: 0;
+    }
+}

--- a/conf.py
+++ b/conf.py
@@ -50,10 +50,7 @@ exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
 # a list of builtin themes.
 #
 html_theme = "alabaster"
-html_theme_options = {
-    'fixed_sidebar': 'true',
-    'page_width':'1500px'
-}
+html_static_path = ['_static']
 
 html_sidebars = {
         '**': ['localtoc.html', 'searchbox.html', 'version.html'],


### PR DESCRIPTION
We have updated our used sphinx and alabaster versions and they had some major breaking changes in the style and our current documentation looks a bit off. These changes ensures that we have the same style like before.